### PR TITLE
Fix #1 read_proc_format() works with less well formatted format files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: grkmisc
 Title: A package of miscellaneously helpful functions.
-Version: 0.0.0.9047
+Version: 0.0.0.9048
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/R/read_proc_format.R
+++ b/R/read_proc_format.R
@@ -69,6 +69,7 @@ expand_varnames <- function(pfdf) {
   pfdf_names <- names(pfdf)
 
   pfdf %>%
+    fill_missing_format() %>%
     split(.$format) %>%
     purrr::map_df(~ cbind(
       .[, setdiff(pfdf_names, "varname")],
@@ -93,6 +94,21 @@ expand_varname <- function(varname) {
     return(varname)
   }
   paste0(var_base, var_indexes[1]:var_indexes[2])
+}
+
+fill_missing_varname <- function(pfdf) {
+  if (!any(is.na(pfdf$varname))) return(pfdf)
+  pfdf %>%
+    dplyr::mutate(
+      varname = ifelse(is.na(varname), sub("value (.+?)\n.+", "\\1", value), varname)
+    )
+}
+
+fill_missing_format <- function(pfdf) {
+  if (!any(is.na(pfdf$format))) return(pfdf)
+  if (any(is.na(pfdf$varname))) pfdf <- fill_missing_varname(pfdf)
+  pfdf[is.na(pfdf$format), "format"] <- pfdf[is.na(pfdf$format), "varname"]
+  pfdf
 }
 
 null_vartype <- function(vartype) {

--- a/tests/testthat/test-read_proc_format.R
+++ b/tests/testthat/test-read_proc_format.R
@@ -71,3 +71,19 @@ test_that("works without fancy extra formatting", {
   expect_equal(x$value, expected_value_text)
   expect_equal(length(x$label[[1]]), 6)
 })
+
+test_that("strips inline comments", {
+  comment_format_file <- tempfile(fileext = "sas")
+  comment_format_text <- c(
+    "proc format;",
+    "value qstatusr",
+    '1 = "(1) Complete" /* with "comment" here */',
+    'run;'
+  )
+  cat(comment_format_text, file=comment_format_file, sep = "\n")
+  x <- read_proc_format(comment_format_file)
+
+  expect_equal(x$varname, "qstatusr")
+  expect_equal(x$value, 'value qstatusr\n1 = "(1) Complete" ')
+  expect_equal(x$label[[1]], c('(1) Complete' = 1))
+})

--- a/tests/testthat/test-read_proc_format.R
+++ b/tests/testthat/test-read_proc_format.R
@@ -46,3 +46,28 @@ test_that("proc format statements covering multiple variables x0-5", {
   expect_equal(unique(pfdf$format), "biopplink0v")
   expect_equal(nrow(pfdf), length(0:5))
 })
+
+test_that("works without fancy extra formatting", {
+  bare_format_file <- tempfile(fileext = "sas")
+  bare_format_text <- c(
+    "proc format;",
+    "value qstatusr",
+    '1 = "(1) Complete"',
+    '2 = "(2) Incomplete"',
+    '3 = "(3) Not returned"',
+    '4 = "(4) Entered once"',
+    '5 = "(5) Validated"',
+    '6 = "(6) Deceased"',
+    ';',
+    'run;'
+  )
+  cat(bare_format_text, file=bare_format_file, sep = "\n")
+  expected_value_text <- paste(bare_format_text[c(-1, 0:1 - length(bare_format_text))], collapse = "\n")
+  expected_value_text <- paste0(expected_value_text, "\n")
+
+  x <- read_proc_format(bare_format_file)
+  expect_equal(x$varname, "qstatusr")
+  expect_equal(x$format, "qstatusr")
+  expect_equal(x$value, expected_value_text)
+  expect_equal(length(x$label[[1]]), 6)
+})


### PR DESCRIPTION
Fills missing `format` and `varname` columns that were pulled from machine-written comments that are not likely to be found in handmade format files.