### PR TITLE
add small font size spec to css

### DIFF
--- a/data-raw/00-moffitt-theme.R
+++ b/data-raw/00-moffitt-theme.R
@@ -58,6 +58,9 @@ duo_accent(
       "font-style" = "italic",
       color = "#777"
     ),
+    ".small" = list(
+      "font-size" = ".5em"
+    ),
     ".large" = list(
       "font-size" = "1.5em"
     ),

--- a/inst/rmarkdown/templates/moffitt-xaringan/skeleton/moffitt-xaringan.css
+++ b/inst/rmarkdown/templates/moffitt-xaringan/skeleton/moffitt-xaringan.css
@@ -241,11 +241,20 @@ blockquote {
   font-style: italic;
   color: #777;
 }
-.large {
-  font-size: 1.5em;
+.smaller {
+  font-size: 0.5em;
+}
+.small {
+  font-size: 0.75em;
 }
 .big {
-  font-size: 2em;
+  font-size: 1.5em;
+}
+.bigger {
+  font-size: 2.0em;
+}
+.huge {
+  font-size: 3.0em;
 }
 .third {
   width: 33%;


### PR DESCRIPTION
I'm often modifying `moffitt-xaringan.css` after invoking `doc_new()` to add a `.small` font setting. This update makes `doc_new()` add those lines to the css.